### PR TITLE
Fix appengine deployment

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -1,6 +1,6 @@
-runtime: go
+runtime: go114
 api_version: go1
 
 handlers:
-- url: /.*
-  script: _go_app
+  - url: /.*
+    script: _go_app

--- a/appengine/main.go
+++ b/appengine/main.go
@@ -1,12 +1,26 @@
 package main
 
 import (
-	"github.com/standupdev/runefinder"
-	"google.golang.org/appengine"
+	"log"
 	"net/http"
+	"os"
+
+	"github.com/standupdev/runefinder"
 )
 
 func main() {
 	http.HandleFunc("/", runefinder.Home)
-	appengine.Main()
+	port := getPort()
+	log.Printf("listening on :%s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func getPort() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	return port
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/standupdev/runefinder
+
+go 1.14
+
+require (
+	github.com/standupdev/runeset v1.0.0
+	golang.org/x/text v0.3.4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/standupdev/runeset v1.0.0 h1:aKS5ummq5Mc3CtXOhXdyE29mSL1/LUL9Dg0PnaV8BSQ=
+github.com/standupdev/runeset v1.0.0/go.mod h1:tmBj7QsZ/7uaayqaql2sSLpaHrWQ6MLC1IXaKU9q9To=
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
This fixes the compatiblity with GAE's 2nd-gen runtime, in which special
libraries are no longer required.

This was a 3-step change:

- update app.yaml to use a 2nd-gen runtime
- adopt go modules
- update server code to use the standard-library instead of
appengine-specialized library (this is actually optional, but doing that
makes it easier to run the service locally)